### PR TITLE
Use `gpg2' instead of `gpgv2', don't try to recreate keyring

### DIFF
--- a/firefox-overlay.nix
+++ b/firefox-overlay.nix
@@ -62,7 +62,7 @@ let
       HOME=`mktemp -d`
       set -eux
       cat ${./firefox.key} | gpg2 --import
-      gpgv2 --keyring=$HOME/.gnupg/pubring.kbx $CHKSUM_ASC $CHKSUM_FILE
+      gpg2 --verify $CHKSUM_ASC $CHKSUM_FILE
       mkdir $out
     '';
 


### PR DESCRIPTION
`gpgv2' is no longer available via `self.gnupg', so move to using
`gpg2 --verify'.

Specifying `--keyring=...' tries to recreate the keyring and causes a
nonzero exit status, so remove the option.